### PR TITLE
Easier to access RetroLab tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ jupyter labextension list
 
 Should also be available when starting `retrolab`.
 
+### Launching
+
+From an open notebook:
+
+1. Click the RetroLab button in the toolbar; or
+2. View > Open in RetroLab from the menu
+
+To access the main RetroLab tree (file browser):
+
+1. Help > Launch RetroLab Tree from the menu; or
+2. Go to the /retro URL path of your Jupyter site
+
+## Tour
+
 ### Files 📂 and Running Sessions 🏃‍♀️
 
 ![tree](https://user-images.githubusercontent.com/591645/101952684-54c4a100-3bf9-11eb-8031-6900f6d3a445.gif)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ From an open notebook:
 
 To access the main RetroLab tree (file browser):
 
-1. Help > Launch RetroLab Tree from the menu; or
+1. Help > Launch RetroLab File Browser from the menu; or
 2. Go to the /retro URL path of your Jupyter site
 
 ## Tour

--- a/packages/lab-extension/src/index.ts
+++ b/packages/lab-extension/src/index.ts
@@ -146,7 +146,7 @@ const launchRetroTree: JupyterFrontEndPlugin<void> = {
     const category = trans.__('Help');
 
     commands.addCommand(CommandIDs.launchRetroTree, {
-      label: trans.__('Launch RetroLab Tree'),
+      label: trans.__('Launch RetroLab File Browser'),
       execute: () => {
         window.open(PageConfig.getBaseUrl() + 'retro/tree');
       }

--- a/packages/lab-extension/src/index.ts
+++ b/packages/lab-extension/src/index.ts
@@ -15,6 +15,8 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
+import { ITranslator } from '@jupyterlab/translation';
+
 import {
   INotebookModel,
   INotebookTracker,
@@ -35,6 +37,7 @@ namespace CommandIDs {
    * Toggle Top Bar visibility
    */
   export const openRetro = 'retrolab:open';
+  export const launchRetroTree = 'retrolab:launchtree';
 }
 
 /**
@@ -125,8 +128,44 @@ const openRetro: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin to add a command to open the RetroLab Tree.
+ */
+const launchRetroTree: JupyterFrontEndPlugin<void> = {
+  id: '@retrolab/lab-extension:launch-retrotree',
+  autoStart: true,
+  requires: [ITranslator],
+  optional: [IMainMenu, ICommandPalette],
+  activate: (
+    app: JupyterFrontEnd,
+    translator: ITranslator,
+    menu: IMainMenu | null,
+    palette: ICommandPalette | null
+  ): void => {
+    const { commands } = app;
+    const trans = translator.load('jupyterlab');
+    const category = trans.__('Help');
+
+    commands.addCommand(CommandIDs.launchRetroTree, {
+      label: trans.__('Launch RetroLab Tree'),
+      execute: () => {
+        window.open(PageConfig.getBaseUrl() + 'retro/tree');
+      }
+    });
+
+    if (menu) {
+      const helpMenu = menu.helpMenu;
+      helpMenu.addGroup([{ command: CommandIDs.launchRetroTree }], 1);
+    }
+
+    if (palette) {
+      palette.addItem({ command: CommandIDs.launchRetroTree, category });
+    }
+  }
+};
+
+/**
  * Export the plugins as default.
  */
-const plugins: JupyterFrontEndPlugin<any>[] = [openRetro];
+const plugins: JupyterFrontEndPlugin<any>[] = [launchRetroTree, openRetro];
 
 export default plugins;

--- a/retrolab/app.py
+++ b/retrolab/app.py
@@ -77,6 +77,12 @@ class RetroHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHan
         return page_config
 
 
+class RetroRedirectHandler(RetroHandler):
+    @web.authenticated
+    def get(self):
+        return self.redirect(self.base_url+'retro/tree')
+
+
 class RetroTreeHandler(RetroHandler):
     @web.authenticated
     def get(self, path=None):
@@ -152,6 +158,7 @@ class RetroApp(NBClassicConfigShimMixin, LabServerApp):
                 {"url": "/retro/edit/{0}"},
             )
         )
+        self.handlers.append(("/retro/?", RetroRedirectHandler))
         self.handlers.append(("/retro/tree(.*)", RetroTreeHandler))
         self.handlers.append(("/retro/notebooks(.*)", RetroNotebookHandler))
         self.handlers.append(("/retro/edit(.*)", RetroFileHandler))


### PR DESCRIPTION
Add Help > Launch RetroLab Tree to the menu

Redirect from /retro or /retro/ to /retro/tree

Closes #134 