### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: '*'
 
+permissions:
+  contents:
+    write
+
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
@@ -21,8 +25,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Build checksum file
       run: |
-        sed -n 17,146p .github/workflows/build.yml > build
-        sed -n 17,146p .github/workflows/release.yml > release
+        sed -n 20,146p .github/workflows/build.yml > build
+        sed -n 20,146p .github/workflows/release.yml > release
         diff build release
 
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - '*'
 
 
+permissions:
+  contents:
+    write
+
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
@@ -21,8 +25,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Build checksum file
       run: |
-        sed -n 17,146p .github/workflows/build.yml > build
-        sed -n 17,146p .github/workflows/release.yml > release
+        sed -n 20,146p .github/workflows/build.yml > build
+        sed -n 20,146p .github/workflows/release.yml > release
         diff build release
 
   test:
@@ -219,7 +223,7 @@ jobs:
         docker run --rm -v "$(pwd)":/usr/local/src/your-app \
           -e CHANGELOG_GITHUB_TOKEN=${CHANGELOG_GITHUB_TOKEN} \
           ferrarimarco/github-changelog-generator \
-          github_changelog_generator -u jtpio -p retrolab --usernames-as-github-logins --no-issues --no-unreleased \
+          github_changelog_generator -u jupyterlab -p retrolab --usernames-as-github-logins --no-issues --no-unreleased \
           --since-tag ${{ steps.previous_tag.outputs.tag }} --header "" --pr-label "## Changes"
         head -n -1 CHANGELOG.md > CHANGELOG
     - name: Create Release


### PR DESCRIPTION
- Use `jupyterlab` as the org name when generating the changelog
- Fix permissions (the last run failed on the creation of the release: https://github.com/jupyterlab/retrolab/runs/2693473436?check_suite_focus=true)