### PR TITLE
Add check-release CI workflow and Changelog

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,56 @@
+name: Check Release
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+permissions:
+  contents:
+    write
+
+jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: "x64"
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache checked links
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pytest-link-check
+          key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/.md') }}-md-links
+          restore-keys: |
+            ${{ runner.os }}-linkcheck-
+      - name: Upgrade packaging dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel jupyter-packaging~=0.7.9 --user
+      - name: Install Dependencies
+        run: |
+          pip install .
+      - name: Check Release
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,26 +206,6 @@ jobs:
         echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
         cp ~/.npmrc .npmrc
         jlpm release:npm --dist ./pkgs
-    - name: Get the current tag
-      id: current_tag
-      run: |
-        tag=`git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1)`
-        echo "::set-output name=tag::${tag}"
-    - name: Get the previous tag
-      id: previous_tag
-      run: |
-        tag=`git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1)`
-        echo "::set-output name=tag::${tag}"
-    - name: Generate Changelog
-      env:
-        CHANGELOG_GITHUB_TOKEN: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}
-      run: |
-        docker run --rm -v "$(pwd)":/usr/local/src/your-app \
-          -e CHANGELOG_GITHUB_TOKEN=${CHANGELOG_GITHUB_TOKEN} \
-          ferrarimarco/github-changelog-generator \
-          github_changelog_generator -u jupyterlab -p retrolab --usernames-as-github-logins --no-issues --no-unreleased \
-          --since-tag ${{ steps.previous_tag.outputs.tag }} --header "" --pr-label "## Changes"
-        head -n -1 CHANGELOG.md > CHANGELOG
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -234,8 +214,6 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
-        body_path: CHANGELOG
         # TODO: set to false?
         draft: true
         prerelease: ${{ contains(github.ref, 'a') || contains(github.ref, 'b') || contains(github.ref, 'rc') }}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- <START NEW CHANGELOG ENTRY> -->
+
 ## v0.3.0rc0
 
 ([full changelog](https://github.com/jupyterlab/retrolab/compare/0.3.0b0...96671df35822f09721fd2e5df7118ce4fa2225ea))
@@ -19,6 +21,8 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-07-06&to=2021-07-14&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2021-07-06..2021-07-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-07-06..2021-07-14&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v0.3.0b0
 

--- a/package.json
+++ b/package.json
@@ -69,5 +69,10 @@
     "rimraf": "^3.0.2",
     "shell-quote": "^1.7.2",
     "typescript": "~4.1.3"
+  },
+  "jupyter-releaser": {
+    "hooks": {
+      "before-bump-version": "python -m pip install bump2version"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@retrolab/root",
+  "version": "0.3.0-beta.0",
   "private": true,
   "homepage": "https://github.com/jupyterlab/retrolab",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@retrolab/root",
   "private": true,
   "homepage": "https://github.com/jupyterlab/retrolab",
   "bugs": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tools.jupyter-releaser.hooks]
-before-prep-git = ["python -m pip install bump2version"]
+before-bump-version = ["python -m pip install bump2version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ factory = "jupyter_packaging.npm_builder"
 [tool.jupyter-packaging.build-args]
 build_cmd = "build:prod"
 npm = ["jlpm"]
+
+[tools.jupyter-releaser.hooks]
+before-prep-git = ["python -m pip install bump2version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,3 @@ factory = "jupyter_packaging.npm_builder"
 [tool.jupyter-packaging.build-args]
 build_cmd = "build:prod"
 npm = ["jlpm"]
-
-[tools.jupyter-releaser.hooks]
-before-bump-version = ["python -m pip install bump2version"]


### PR DESCRIPTION
In preparation for using the Jupyter Releaser: https://github.com/jupyterlab/retrolab/issues/136

- [x] Adopt markers for the changelog
- [x] Remove the changelog generation from the `release` CI workflow since we'll be using `github-activity` instead