### PR TITLE
Provide `IStateDB`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -102,6 +102,7 @@ async function main() {
       [
         '@jupyterlab/apputils-extension:palette',
         '@jupyterlab/apputils-extension:settings',
+        '@jupyterlab/apputils-extension:state',
         '@jupyterlab/apputils-extension:themes',
         '@jupyterlab/apputils-extension:themes-palette-menu'
       ].includes(id)


### PR DESCRIPTION
Similar to https://github.com/jupyterlite/jupyterlite/pull/287, so extensions like `jupyterlab-tour` work in RetroLab.