### PR TITLE
Automated Changelog Entry for 0.3.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.0
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/0.3.0rc1...2f06d80c12f720d2c457b0db5a57390f004819f4))
+
+### Maintenance and upkeep improvements
+
+- Update to JupyterLab 3.1 final [#189](https://github.com/jupyterlab/retrolab/pull/189) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-07-23&to=2021-08-27&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-07-23..2021-08-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.0rc1
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/0.3.0rc0...9eaa171504b94869b850a46b97f748394d2154fa))
@@ -21,8 +37,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-07-14&to=2021-07-22&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2021-07-14..2021-07-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-07-14..2021-07-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v0.3.0rc0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.0 on main
Python version: 0.3.0
npm version: @retrolab/root: 0.3.0-rc.0
npm workspace versions:
@retrolab/app: 0.3.0-rc.1
@retrolab/buildutils: 0.3.0-rc.1
@retrolab/application-extension: 0.3.0-rc.1
@retrolab/tree-extension: 0.3.0-rc.1
@retrolab/ui-components: 0.3.0-rc.1
@retrolab/application: 0.3.0-rc.1
@retrolab/help-extension: 0.3.0-rc.1
@retrolab/lab-extension: 0.3.0-rc.1
@retrolab/notebook-extension: 0.3.0-rc.1
@retrolab/metapackage: 0.3.0-rc.1
@retrolab/terminal-extension: 0.3.0-rc.1
@retrolab/docmanager-extension: 0.3.0-rc.1

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | main  |
| Version Spec | release |
| Since | 0.3.0rc1 |