### PR TITLE
Automated Changelog Entry for 0.3.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.2
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/0.3.1...ab319333c993ba2765ef0e31c5f905c5b9578dd8))
+
+### New features added
+
+- Add support for code consoles [#197](https://github.com/jupyterlab/retrolab/pull/197) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-08-28&to=2021-08-30&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Abollwyvl+updated%3A2021-08-28..2021-08-30&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-08-28..2021-08-30&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.1
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/0.3.0...660066f7c58763bff9afcfcbaf005660f9889085))
@@ -19,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-08-27&to=2021-08-28&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2021-08-27..2021-08-28&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-08-27..2021-08-28&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.2 on main
Python version: 0.3.2
npm version: @retrolab/root: 0.3.0-rc.0
npm workspace versions:
@retrolab/app: 0.3.2
@retrolab/buildutils: 0.3.2
@retrolab/application-extension: 0.3.2
@retrolab/tree-extension: 0.3.2
@retrolab/ui-components: 0.3.2
@retrolab/application: 0.3.2
@retrolab/console-extension: 0.3.2
@retrolab/help-extension: 0.3.2
@retrolab/lab-extension: 0.3.2
@retrolab/notebook-extension: 0.3.2
@retrolab/metapackage: 0.3.2
@retrolab/terminal-extension: 0.3.2
@retrolab/docmanager-extension: 0.3.2

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | main  |
| Version Spec | patch |
| Since | 0.3.1 |