### PR TITLE
Try with `jupyter_releaser` v0.5.2

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -72,7 +72,7 @@ jobs:
           echo "::set-output name=spec::${version_spec}"
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v0.5.2
         env:
           RH_VERSION_SPEC: ${{ steps.version-spec.outputs.spec }}
         with:


### PR DESCRIPTION
Since the check release on `main` started to fail with the latest version after merging https://github.com/jupyterlab/retrolab/pull/208:

https://github.com/jupyterlab/retrolab/runs/3535195754