### PR TITLE
Fix handling of skip-commit

### DIFF
--- a/buildutils/src/release-bump.ts
+++ b/buildutils/src/release-bump.ts
@@ -33,6 +33,9 @@ commander
       if (opts.force) {
         cmd += ' --force';
       }
+      if (opts.skipCommit) {
+        cmd += ' --skip-commit';
+      }
       utils.run(cmd);
       process.exit(0);
     }

--- a/buildutils/src/release-patch.ts
+++ b/buildutils/src/release-patch.ts
@@ -17,6 +17,7 @@ import { postbump } from './utils';
 commander
   .description('Create a patch release')
   .option('--force', 'Force the upgrade')
+  .option('--skip-commit', 'Whether to skip commit changes')
   .action((options: any) => {
     // Make sure we can patch release.
     const pyVersion = utils.getPythonVersion();
@@ -45,8 +46,9 @@ commander
     }
     utils.run(cmd);
 
-    // Run post-bump actions.
-    postbump();
+    // Whether to commit after bumping
+    const commit = options.skipCommit !== true;
+    postbump(commit);
   });
 
 commander.parse(process.argv);


### PR DESCRIPTION
Pass `--skip-commit` to the patch version command.

Might fix #205 

Spotted when attempting to make a release with the releaser: https://github.com/jtpio/jupyter_releaser/runs/3545811481