### PR TITLE
Fix clean:static to not clean the console favicon

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf build && jlpm run clean:static",
     "clean:artifacts": "rimraf artifacts",
-    "clean:static": "rimraf ../retrolab/static",
+    "clean:static": "rimraf -g \"../retrolab/static/!(favicons)\"",
     "prepublishOnly": "yarn run build",
     "test:e2e": "jlpm run clean:artifacts && playwright test",
     "test:e2e:pwdebug": "jlpm run clean:artifacts && PWDEBUG=1 jlpm run test:e2e",


### PR DESCRIPTION
So the `clean` script doesn't remove the console favicon under `static`.