### PR TITLE
Update RELEASE.md to mention the Jupyter Releaser

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,30 +2,9 @@
 
 ## Automated releases
 
-Releases are automated using GitHub Actions. They are triggered when a new tag is pushed to the remote.
-
-To cut a new release, run the following:
-
-```bash
-# checkout the main branch
-git checkout main
-
-# for a patch release
-jlpm release:patch
-
-# for a minor version bump
-jlpm release:bump minor
-
-# for a major version bump
-jlpm release:bump major
-
-# push to the main branch
-git push origin main --tags
-```
+The recommended way to make a release is to use [`jupyter_releaser`](https://github.com/jupyter-server/jupyter_releaser#checklist-for-adoption).
 
 We follow a similar bump strategy as in JupyterLab: https://github.com/jupyterlab/jupyterlab/blob/master/RELEASE.md#bump-version
-
-The release workflow also creates a GitHub release with the new changes generated with [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
 
 If you would still like to do the release manually instead, read below.
 


### PR DESCRIPTION
The last releases were done with the Jupyter Releaser and it's now the recommended way to make releases.