### PR TITLE
Simplify bump version script

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -58,22 +58,9 @@ jobs:
         run: |
           pip install .
 
-      - name: Configure Version Spec
-        id: version-spec
-        if: ${{ matrix.group == 'check_release' }}
-        run: |
-          set -eux
-          version=$(python setup.py --version)
-          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version_spec=patch
-          else
-            version_spec=build
-          fi
-          echo "::set-output name=spec::${version_spec}"
-
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         env:
-          RH_VERSION_SPEC: ${{ steps.version-spec.outputs.spec }}
+          RH_VERSION_SPEC: next
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/buildutils/src/release-bump.ts
+++ b/buildutils/src/release-bump.ts
@@ -23,9 +23,15 @@ commander
   .action((spec: any, opts: any) => {
     // Get the previous version.
     const prev = utils.getPythonVersion();
+    const isFinal = /\d+\.\d+\.\d+$/.test(prev);
 
     // Whether to commit after bumping
     const commit = opts.skipCommit !== true;
+
+    // for "next", determine whether to use "patch" or "build"
+    if (spec === 'next') {
+      spec = isFinal ? 'patch' : 'build';
+    }
 
     // For patch, defer to `patch:release` command
     if (spec === 'patch') {
@@ -45,20 +51,10 @@ commander
     if (options.indexOf(spec) === -1) {
       throw new Error(`Version spec must be one of: ${options}`);
     }
-    if (
-      prev.indexOf('a') === -1 &&
-      prev.indexOf('b') === -1 &&
-      prev.indexOf('rc') === -1 &&
-      spec === 'release'
-    ) {
+    if (isFinal && spec === 'release') {
       throw new Error('Use "major" or "minor" to switch back to alpha release');
     }
-    if (
-      prev.indexOf('a') === -1 &&
-      prev.indexOf('b') === -1 &&
-      prev.indexOf('rc') === -1 &&
-      spec === 'build'
-    ) {
+    if (isFinal && spec === 'build') {
       throw new Error('Cannot increment a build on a final release');
     }
 

--- a/buildutils/src/release-bump.ts
+++ b/buildutils/src/release-bump.ts
@@ -39,7 +39,7 @@ commander
       if (opts.force) {
         cmd += ' --force';
       }
-      if (opts.skipCommit) {
+      if (commit) {
         cmd += ' --skip-commit';
       }
       utils.run(cmd);


### PR DESCRIPTION
To use `next` for both `build` and `patch`.

Similar to the upstream PR: https://github.com/jupyterlab/jupyterlab/pull/11056