### PR TITLE
Automated Changelog Entry for 0.3.7 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.3.7
 
-([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.6...d720af21ba271d7e9306bcc25385bc6cefd4adb3))
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.6...986ce55f74bd663512122f727a2f487d5df77eb2))
 
 ### Enhancements made
 
@@ -13,12 +13,15 @@
 
 ### Maintenance and upkeep improvements
 
+- Fix handling of `--skip-commit` [#232](https://github.com/jupyterlab/retrolab/pull/232) ([@jtpio](https://github.com/jtpio))
 - Simplify bump version script [#224](https://github.com/jupyterlab/retrolab/pull/224) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
 
 - Add a Binder section to the readme [#230](https://github.com/jupyterlab/retrolab/pull/230) ([@jtpio](https://github.com/jtpio))
 - Update RELEASE.md to mention the Jupyter Releaser [#223](https://github.com/jupyterlab/retrolab/pull/223) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.7 on main
Python version: 0.3.7
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.7
@retrolab/buildutils: 0.3.7
@retrolab/application-extension: 0.3.7
@retrolab/console-extension: 0.3.7
@retrolab/notebook-extension: 0.3.7
@retrolab/docmanager-extension: 0.3.7
@retrolab/metapackage: 0.3.7
@retrolab/lab-extension: 0.3.7
@retrolab/tree-extension: 0.3.7
@retrolab/terminal-extension: 0.3.7
@retrolab/help-extension: 0.3.7
@retrolab/ui-components: 0.3.7
@retrolab/application: 0.3.7

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.3.6 |