### PR TITLE
Support disabling core retrolab extensions

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -311,7 +311,7 @@ async function main() {
       console.error(reason);
     });
 
-  app.registerPluginModules(baseMods);
+  app.registerPluginModules(mods);
 
   // Expose global app instance when in dev mode or when toggled explicitly.
   const exposeAppInBrowser =


### PR DESCRIPTION
Fixes #241 

For example, running `jupyter labextension disable @retrolab/application-extension:logo` and reloading the page:

![image](https://user-images.githubusercontent.com/591645/136436699-81da757c-12ce-40f1-92d3-27a8f1f43e7b.png)
