### PR TITLE
Improve tree page tab bar CSS

### DIFF
--- a/packages/tree-extension/style/base.css
+++ b/packages/tree-extension/style/base.css
@@ -9,6 +9,12 @@
 .jp-TreePanel .lm-TabPanel-tabBar {
   overflow: visible;
   min-height: 32px;
+  border-bottom: unset;
+  height: var(--jp-private-toolbar-height);
+}
+
+.jp-TreePanel .lm-TabBar-content {
+  height: 100%;
 }
 
 .jp-TreePanel .lm-TabBar-tab {


### PR DESCRIPTION
So the borders look a bit nicer:

### Before

![image](https://user-images.githubusercontent.com/591645/136439184-2598f1d8-526e-401c-baac-4f20382996a0.png)


### After

![image](https://user-images.githubusercontent.com/591645/136439070-01ed4b36-90ab-4f75-b4dd-7753a9ca6875.png)
