### PR TITLE
Automated Changelog Entry for 0.3.8 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.8
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.7...812e76db12dce15acc3ff582fd7cfb009fd33879))
+
+### Enhancements made
+
+- More document-oriented feel for the notebook (scrollbar) [#244](https://github.com/jupyterlab/retrolab/pull/244) ([@jtpio](https://github.com/jtpio))
+- Improve tree page tab bar CSS [#243](https://github.com/jupyterlab/retrolab/pull/243) ([@jtpio](https://github.com/jtpio))
+- Add missing translations to help extension [#237](https://github.com/jupyterlab/retrolab/pull/237) ([@krassowski](https://github.com/krassowski))
+
+### Bugs fixed
+
+- Fix handling of federated extensions [#245](https://github.com/jupyterlab/retrolab/pull/245) ([@jtpio](https://github.com/jtpio))
+- Support disabling core retrolab extensions [#242](https://github.com/jupyterlab/retrolab/pull/242) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Update link to the stable Binder [#236](https://github.com/jupyterlab/retrolab/pull/236) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-09-23&to=2021-10-11&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2021-09-23..2021-10-11&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-09-23..2021-10-11&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Akrassowski+updated%3A2021-09-23..2021-10-11&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Awelcome+updated%3A2021-09-23..2021-10-11&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.7
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.6...986ce55f74bd663512122f727a2f487d5df77eb2))
@@ -28,8 +55,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-09-10&to=2021-09-23&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2021-09-10..2021-09-23&type=Issues) | [@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agoanpeca+updated%3A2021-09-10..2021-09-23&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-09-10..2021-09-23&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.6
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.8 on main

```
Python version: 0.3.8
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.8
@retrolab/buildutils: 0.3.8
@retrolab/notebook-extension: 0.3.8
@retrolab/console-extension: 0.3.8
@retrolab/tree-extension: 0.3.8
@retrolab/docmanager-extension: 0.3.8
@retrolab/help-extension: 0.3.8
@retrolab/lab-extension: 0.3.8
@retrolab/application: 0.3.8
@retrolab/terminal-extension: 0.3.8
@retrolab/metapackage: 0.3.8
@retrolab/ui-components: 0.3.8
@retrolab/application-extension: 0.3.8
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.3.7 |