### PR TITLE
Hoist the filebrowser factory plugin

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -203,10 +203,7 @@ async function main() {
           ['@jupyterlab/completer-extension:files'].includes(id)
         ),
         require('@jupyterlab/filebrowser-extension').default.filter(({ id }) =>
-          [
-            '@jupyterlab/filebrowser-extension:browser',
-            '@jupyterlab/filebrowser-extension:factory'
-          ].includes(id)
+          ['@jupyterlab/filebrowser-extension:browser'].includes(id)
         )
       ]);
       break;


### PR DESCRIPTION
Fixes #248 

This brings a couple more items to the `File > New` menu entry.

### Before

![image](https://user-images.githubusercontent.com/591645/136853929-2f677898-504f-4cd7-8914-c86f7d7660c9.png)

### After

![image](https://user-images.githubusercontent.com/591645/136853805-24451fad-4d77-4b6b-a803-c3fccf960428.png)
