### PR TITLE
Pass version spec as a GitHub Actions input

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
-        env:
-          RH_VERSION_SPEC: next
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version_spec: next


### PR DESCRIPTION
Similar change as in JupyterLab: https://github.com/jupyterlab/jupyterlab/pull/11322

To take into account the latest changes in Jupyter Releaser.