### PR TITLE
Fix missing download command

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -119,11 +119,17 @@ async function main() {
     ),
     require('@jupyterlab/console-extension'),
     require('@jupyterlab/docmanager-extension').default.filter(({ id }) =>
-      ['@jupyterlab/docmanager-extension:plugin'].includes(id)
+      [
+        '@jupyterlab/docmanager-extension:plugin',
+        '@jupyterlab/docmanager-extension:download'
+      ].includes(id)
     ),
     require('@jupyterlab/docprovider-extension'),
     require('@jupyterlab/filebrowser-extension').default.filter(({ id }) =>
-      ['@jupyterlab/filebrowser-extension:factory'].includes(id)
+      [
+        '@jupyterlab/filebrowser-extension:factory',
+        '@jupyterlab/filebrowser-extension:download'
+      ].includes(id)
     ),
     require('@jupyterlab/fileeditor-extension').default.filter(({ id }) =>
       ['@jupyterlab/fileeditor-extension:plugin'].includes(id)


### PR DESCRIPTION
Add back the Download menu and context menu items as reported in #259.

The download functionality has been moved to separate plugins in upstream JupyterLab which is why they were not picked up in RetroLab anymore. 

A pass on #228 should help catch these regressions when updating to newer `@jupyterlab` packages.