### PR TITLE
Automated Changelog Entry for 0.3.12 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.12
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.11...8d92d7ff18a0b57d9aa1f64952064d3babc87de1))
+
+### Bugs fixed
+
+- Fix missing download command [#263](https://github.com/jupyterlab/retrolab/pull/263) ([@jtpio](https://github.com/jtpio))
+- Fix handling of federated mime extensions [#262](https://github.com/jupyterlab/retrolab/pull/262) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Pass version spec as a GitHub Actions input [#254](https://github.com/jupyterlab/retrolab/pull/254) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Update the top screenshot in the README [#255](https://github.com/jupyterlab/retrolab/pull/255) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-10-14&to=2021-11-01&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2021-10-14..2021-11-01&type=Issues) | [@gutow](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agutow+updated%3A2021-10-14..2021-11-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-10-14..2021-11-01&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.11
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.10...29c41d3b005701fcc2d7a0760addc65858b7231b))
@@ -15,8 +40,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2021-10-14&to=2021-10-14&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2021-10-14..2021-10-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.10
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.12 on main
```
Python version: 0.3.12
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.12
@retrolab/buildutils: 0.3.12
@retrolab/notebook-extension: 0.3.12
@retrolab/console-extension: 0.3.12
@retrolab/tree-extension: 0.3.12
@retrolab/docmanager-extension: 0.3.12
@retrolab/help-extension: 0.3.12
@retrolab/lab-extension: 0.3.12
@retrolab/application: 0.3.12
@retrolab/terminal-extension: 0.3.12
@retrolab/metapackage: 0.3.12
@retrolab/ui-components: 0.3.12
@retrolab/application-extension: 0.3.12
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.3.11 |