### PR TITLE
Move the kernel name and status icon to the menu bar

### DIFF
--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -56,7 +56,8 @@
     "access": "public"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   },
   "styleModule": "style/index.js"
 }

--- a/packages/notebook-extension/schema/kernel-name.json
+++ b/packages/notebook-extension/schema/kernel-name.json
@@ -1,0 +1,22 @@
+{
+  "title": "RetroLab Kernel Name",
+  "description": "RetroLab Kernel Name Settings",
+  "jupyter.lab.toolbars": {
+    "Notebook": [
+      { "name": "kernelName", "rank": -1, "disabled": true },
+      { "name": "kernelStatus", "rank": -1, "disabled": true }
+    ]
+  },
+  "jupyter.lab.transform": true,
+  "additionalProperties": false,
+  "properties": {
+    "toolbar": {
+      "title": "Notebook panel toolbar items",
+      "items": {
+        "$ref": "#/definitions/toolbarItem"
+      },
+      "type": "array",
+      "default": []
+    }
+  }
+}

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -23,6 +23,8 @@ import { ITranslator } from '@jupyterlab/translation';
 
 import { RetroApp, IRetroShell } from '@retrolab/application';
 
+import { each } from '@lumino/algorithm';
+
 import { Poll } from '@lumino/polling';
 
 import { Widget } from '@lumino/widgets';
@@ -177,12 +179,26 @@ const kernelName: JupyterFrontEndPlugin<void> = {
         return;
       }
       const sessionContext = current.sessionContext;
-      const widget = Toolbar.createKernelNameItem(
+
+      // TODO: remove this when toolbar customization is available
+      each(current.toolbar.children(), widget => {
+        const w = widget as any;
+        if (w['_statusNames']) {
+          w.dispose();
+          w.parent = null;
+        }
+      });
+
+      const name = Toolbar.createKernelNameItem(
         sessionContext,
         sessionDialogs,
         translator
       );
-      app.shell.add(widget, 'menu', { rank: 12_0000 });
+
+      const status = Toolbar.createKernelStatusItem(sessionContext, translator);
+
+      app.shell.add(name, 'menu', { rank: 12_0000 });
+      app.shell.add(status, 'menu', { rank: 12_0010 });
     };
 
     shell.currentChanged.connect(onChange);
@@ -238,6 +254,7 @@ const kernelStatus: JupyterFrontEndPlugin<void> = {
       if (!(current instanceof NotebookPanel)) {
         return;
       }
+
       const sessionContext = current.sessionContext;
       sessionContext.statusChanged.connect(onStatusChanged);
     };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -6,7 +6,12 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { ISessionContext, DOMUtils } from '@jupyterlab/apputils';
+import {
+  ISessionContext,
+  DOMUtils,
+  Toolbar,
+  ISessionContextDialogs
+} from '@jupyterlab/apputils';
 
 import { Text, Time } from '@jupyterlab/coreutils';
 
@@ -153,6 +158,38 @@ const kernelLogo: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin to display the kernel name in the menu bar.
+ */
+const kernelName: JupyterFrontEndPlugin<void> = {
+  id: '@retrolab/notebook-extension:kernel-name',
+  autoStart: true,
+  requires: [IRetroShell, ITranslator],
+  optional: [ISessionContextDialogs],
+  activate: (
+    app: JupyterFrontEnd,
+    shell: IRetroShell,
+    translator: ITranslator,
+    sessionDialogs: ISessionContextDialogs
+  ) => {
+    const onChange = async () => {
+      const current = shell.currentWidget;
+      if (!(current instanceof NotebookPanel)) {
+        return;
+      }
+      const sessionContext = current.sessionContext;
+      const widget = Toolbar.createKernelNameItem(
+        sessionContext,
+        sessionDialogs,
+        translator
+      );
+      app.shell.add(widget, 'menu', { rank: 12_0000 });
+    };
+
+    shell.currentChanged.connect(onChange);
+  }
+};
+
+/**
  * A plugin to display the kernel status;
  */
 const kernelStatus: JupyterFrontEndPlugin<void> = {
@@ -230,6 +267,7 @@ const paths: JupyterFrontEndPlugin<JupyterFrontEnd.IPaths> = {
 const plugins: JupyterFrontEndPlugin<any>[] = [
   checkpoints,
   kernelLogo,
+  kernelName,
   kernelStatus
 ];
 

--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -47,6 +47,11 @@ body[data-retro='notebooks'] .jp-Notebook.jp-mod-scrollPastEnd::after {
 
 /* ---- */
 
+/* TODO: remove when toobar customization is available */
+.jp-NotebookPanel-toolbar .jp-Toolbar-item.jp-KernelName {
+  display: none;
+}
+
 .jp-RetroKernelLogo {
   flex: 0 0 auto;
   display: flex;


### PR DESCRIPTION
So it's closer to the classic notebook UI:

![image](https://user-images.githubusercontent.com/591645/141506409-27506388-7b1d-4906-90c5-2203461e2345.png)


This is more of a proof of concept for now. If we decide to do this we should check it behaves correctly on mobile too. For now the menu is not properly handled:

![image](https://user-images.githubusercontent.com/591645/141506604-5efbd160-90b4-490c-a0ee-2735167ac256.png)
