### PR TITLE
Remove unused build:test task in app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ retrolab/schemas
 # playwright
 ui-tests/test-results
 ui-tests/playwright-report
+
+# VSCode
+.vscode

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "webpack",
     "build:prod": "webpack --mode=production",
-    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf build && jlpm run clean:static",
     "clean:static": "rimraf -g \"../retrolab/static/!(favicons)\"",
     "prepublishOnly": "yarn run build",


### PR DESCRIPTION
To make `jlpm build:test` work from the top-level.

<s>Should `jlpm test` be run in the CI, btw ?</s> -> https://github.com/jupyterlab/retrolab/blob/main/.github/workflows/build.yml