### PR TITLE
Strip .ipynb extension for display in header and tab title

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -434,8 +434,11 @@ const title: JupyterFrontEndPlugin<void> = {
         return;
       }
 
+      // Don't show the file extension for .ipynb files.
+      const stripIpynb = /\.ipynb$/;
+
       const h = document.createElement('h1');
-      h.textContent = current.title.label;
+      h.textContent = current.title.label.replace(stripIpynb, '');
       widget.node.appendChild(h);
       widget.node.style.marginLeft = '10px';
       if (!docManager) {
@@ -468,8 +471,6 @@ const title: JupyterFrontEndPlugin<void> = {
 
           const newPath = current.context.path ?? result.path;
           const basename = PathExt.basename(newPath);
-          // Don't show the file extension for .ipynb files.
-          const stripIpynb = /\.ipynb$/;
 
           h.textContent = basename.replace(stripIpynb, '');
           if (!router) {

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -56,6 +56,11 @@ const EDITOR_FACTORY = 'Editor';
 const TREE_PATTERN = new RegExp('/(notebooks|edit)/(.*)');
 
 /**
+ * A regular expression to suppress the file extension from display for .ipynb files.
+ */
+const STRIP_IPYNB = /\.ipynb$/;
+
+/**
  * The command IDs used by the application plugin.
  */
 namespace CommandIDs {
@@ -383,7 +388,8 @@ const tabTitle: JupyterFrontEndPlugin<void> = {
           const title =
             current.sessionContext.path || current.sessionContext.name;
           const basename = PathExt.basename(title);
-          document.title = basename;
+          // Strip the ".ipynb" suffix from filenames for display in tab titles.
+          document.title = basename.replace(STRIP_IPYNB, '');
         };
         current.sessionContext.sessionChanged.connect(update);
         update();
@@ -391,7 +397,7 @@ const tabTitle: JupyterFrontEndPlugin<void> = {
       } else if (current instanceof DocumentWidget) {
         const update = () => {
           const basename = PathExt.basename(current.context.path);
-          document.title = basename;
+          document.title = basename.replace(STRIP_IPYNB, '');
         };
         current.context.pathChanged.connect(update);
         update();
@@ -434,11 +440,8 @@ const title: JupyterFrontEndPlugin<void> = {
         return;
       }
 
-      // Don't show the file extension for .ipynb files.
-      const stripIpynb = /\.ipynb$/;
-
       const h = document.createElement('h1');
-      h.textContent = current.title.label.replace(stripIpynb, '');
+      h.textContent = current.title.label.replace(STRIP_IPYNB, '');
       widget.node.appendChild(h);
       widget.node.style.marginLeft = '10px';
       if (!docManager) {
@@ -472,7 +475,7 @@ const title: JupyterFrontEndPlugin<void> = {
           const newPath = current.context.path ?? result.path;
           const basename = PathExt.basename(newPath);
 
-          h.textContent = basename.replace(stripIpynb, '');
+          h.textContent = basename.replace(STRIP_IPYNB, '');
           if (!router) {
             return;
           }

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -468,7 +468,10 @@ const title: JupyterFrontEndPlugin<void> = {
 
           const newPath = current.context.path ?? result.path;
           const basename = PathExt.basename(newPath);
-          h.textContent = basename;
+          // Don't show the file extension for .ipynb files.
+          const stripIpynb = /\.ipynb$/;
+
+          h.textContent = basename.replace(stripIpynb, '');
           if (!router) {
             return;
           }

--- a/ui-tests/test/notebook.spec.ts
+++ b/ui-tests/test/notebook.spec.ts
@@ -34,11 +34,12 @@ test.describe('Notebook', () => {
     const notebook = `${tmpPath}/${NOTEBOOK}`;
     await page.goto(`notebooks/${notebook}`);
 
-    // Click on the title
-    await page.click('text="example.ipynb"');
+    // Click on the title (with .ipynb extension stripped)
+    await page.click('text="example"');
 
     // Rename in the input dialog
     const newName = 'test.ipynb';
+    const newNameStripped = 'test';
     await page.fill(
       `//div[normalize-space(.)='File Path${notebook}New Name']/input`,
       newName
@@ -52,6 +53,6 @@ test.describe('Notebook', () => {
 
     // Check the URL contains the new name
     const url = page.url();
-    expect(url).toContain(newName);
+    expect(url).toContain(newNameStripped);
   });
 });


### PR DESCRIPTION
Fixes #160 by stripping only `.ipynb` from the end of filenames displayed in the workbook title.

Before the change, "Untitled.ipynb" appears to the right of the Jupyter logo in the top area and in the tab title.
![image](https://user-images.githubusercontent.com/93281816/144473301-ec50a150-8fd9-4204-b2d3-95274239f80d.png)

After the change, "Untitled" appears in these areas.
![image](https://user-images.githubusercontent.com/93281816/144475496-04618b67-77fb-4ea1-867b-aa7f1668b795.png)

