### PR TITLE
Fix handling of the Python version in the release scripts

### DIFF
--- a/buildutils/src/release-bump.ts
+++ b/buildutils/src/release-bump.ts
@@ -11,7 +11,7 @@ import * as utils from '@jupyterlab/buildutils';
 
 import commander from 'commander';
 
-import { postbump } from './utils';
+import { getPythonVersion, postbump } from './utils';
 
 // Specify the program signature.
 commander
@@ -22,7 +22,7 @@ commander
   .arguments('<spec>')
   .action((spec: any, opts: any) => {
     // Get the previous version.
-    const prev = utils.getPythonVersion();
+    const prev = getPythonVersion();
     const isFinal = /\d+\.\d+\.\d+$/.test(prev);
 
     // Whether to commit after bumping

--- a/buildutils/src/release-patch.ts
+++ b/buildutils/src/release-patch.ts
@@ -11,7 +11,7 @@ import * as utils from '@jupyterlab/buildutils';
 
 import commander from 'commander';
 
-import { postbump } from './utils';
+import { getPythonVersion, postbump } from './utils';
 
 // Specify the program signature.
 commander
@@ -20,7 +20,7 @@ commander
   .option('--skip-commit', 'Whether to skip commit changes')
   .action((options: any) => {
     // Make sure we can patch release.
-    const pyVersion = utils.getPythonVersion();
+    const pyVersion = getPythonVersion();
     if (
       pyVersion.includes('a') ||
       pyVersion.includes('b') ||

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -1,4 +1,13 @@
-import { getPythonVersion, run } from '@jupyterlab/buildutils';
+import { run } from '@jupyterlab/buildutils';
+
+/**
+ * Get the current version of RetroLab
+ */
+export function getPythonVersion(): string {
+  const cmd = 'python setup.py --version';
+  const lines = run(cmd, { stdio: 'pipe' }, true).split('\n');
+  return lines[lines.length - 1];
+}
 
 export function postbump(commit = true): void {
   // run the integrity


### PR DESCRIPTION
Fix parsing of the Python version via `python setup.py --version`, as a follow-up to the `setuptools` release.

Similar to https://github.com/jupyterlab/jupyterlab/pull/11770