### PR TITLE
Automated Changelog Entry for 0.3.17 on 0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements made
 
-- Backport PR #328: Switch cell type from the cell menu [#334](https://github.com/jupyterlab/retrolab/pull/334) ([@jtpio](https://github.com/jtpio))
+- Switch cell type from the cell menu [#334](https://github.com/jupyterlab/retrolab/pull/334) ([@jtpio](https://github.com/jtpio))
 - Add `Accel Enter` shortcut to execute a cell [#330](https://github.com/jupyterlab/retrolab/pull/330) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.17
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.16...b7e4a513c671699feeb756772b8255ae5381a8fd))
+
+### Enhancements made
+
+- Backport PR #328: Switch cell type from the cell menu [#334](https://github.com/jupyterlab/retrolab/pull/334) ([@jtpio](https://github.com/jtpio))
+- Add `Accel Enter` shortcut to execute a cell [#330](https://github.com/jupyterlab/retrolab/pull/330) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-01-07&to=2022-01-27&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Adavidbrochart+updated%3A2022-01-07..2022-01-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-01-07..2022-01-27&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2022-01-07..2022-01-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ameeseeksmachine+updated%3A2022-01-07..2022-01-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.16
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.15...41a51ac002582baac9a89a2eb3426ac26e16a46f))
@@ -16,8 +33,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-01-03&to=2022-01-07&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Adavidbrochart+updated%3A2022-01-03..2022-01-07&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-01-03..2022-01-07&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2022-01-03..2022-01-07&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3AmartinRenou+updated%3A2022-01-03..2022-01-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Awelcome+updated%3A2022-01-03..2022-01-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.15
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.17 on 0.3.x
```
Python version: 0.3.17
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.17
@retrolab/buildutils: 0.3.17
@retrolab/metapackage: 0.3.17
@retrolab/application: 0.3.17
@retrolab/application-extension: 0.3.17
@retrolab/console-extension: 0.3.17
@retrolab/docmanager-extension: 0.3.17
@retrolab/documentsearch-extension: 0.3.17
@retrolab/help-extension: 0.3.17
@retrolab/lab-extension: 0.3.17
@retrolab/notebook-extension: 0.3.17
@retrolab/terminal-extension: 0.3.17
@retrolab/tree-extension: 0.3.17
@retrolab/ui-components: 0.3.17
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | 0.3.x  |
| Version Spec | next |
| Since | v0.3.16 |