### PR TITLE
Automated Changelog Entry for 0.3.18 on 0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.18
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.17...cc611cf7d114ac0ac73517e379c39899c74d0c57))
+
+### Bugs fixed
+
+- Add `@jupyterlab/notebook-extension:export` plugin [#337](https://github.com/jupyterlab/retrolab/pull/337) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-01-27&to=2022-01-27&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-01-27..2022-01-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ameeseeksmachine+updated%3A2022-01-27..2022-01-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.17
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.16...b7e4a513c671699feeb756772b8255ae5381a8fd))
@@ -16,8 +32,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-01-07&to=2022-01-27&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Adavidbrochart+updated%3A2022-01-07..2022-01-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-01-07..2022-01-27&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2022-01-07..2022-01-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ameeseeksmachine+updated%3A2022-01-07..2022-01-27&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.16
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.18 on 0.3.x
```
Python version: 0.3.18
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.18
@retrolab/buildutils: 0.3.18
@retrolab/metapackage: 0.3.18
@retrolab/application: 0.3.18
@retrolab/application-extension: 0.3.18
@retrolab/console-extension: 0.3.18
@retrolab/docmanager-extension: 0.3.18
@retrolab/documentsearch-extension: 0.3.18
@retrolab/help-extension: 0.3.18
@retrolab/lab-extension: 0.3.18
@retrolab/notebook-extension: 0.3.18
@retrolab/terminal-extension: 0.3.18
@retrolab/tree-extension: 0.3.18
@retrolab/ui-components: 0.3.18
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | 0.3.x  |
| Version Spec | next |
| Since | v0.3.17 |