### PR TITLE
Automated Changelog Entry for 0.3.19 on 0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.19
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.18...f1747296f741a26d6c404120106e3f7902eb830f))
+
+### Maintenance and upkeep improvements
+
+- [0.3.x] Update to JupyterLab 3.2.9 [#345](https://github.com/jupyterlab/retrolab/pull/345) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-01-27&to=2022-02-04&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-01-27..2022-02-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2022-01-27..2022-02-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.18
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.17...cc611cf7d114ac0ac73517e379c39899c74d0c57))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-01-27&to=2022-01-27&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-01-27..2022-01-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ameeseeksmachine+updated%3A2022-01-27..2022-01-27&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Maintenance and upkeep improvements
 
-- [0.3.x] Update to JupyterLab 3.2.9 [#345](https://github.com/jupyterlab/retrolab/pull/345) ([@jtpio](https://github.com/jtpio))
+- Update to JupyterLab 3.2.9 [#345](https://github.com/jupyterlab/retrolab/pull/345) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.19 on 0.3.x
```
Python version: 0.3.19
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.19
@retrolab/buildutils: 0.3.19
@retrolab/metapackage: 0.3.19
@retrolab/application: 0.3.19
@retrolab/application-extension: 0.3.19
@retrolab/console-extension: 0.3.19
@retrolab/docmanager-extension: 0.3.19
@retrolab/documentsearch-extension: 0.3.19
@retrolab/help-extension: 0.3.19
@retrolab/lab-extension: 0.3.19
@retrolab/notebook-extension: 0.3.19
@retrolab/terminal-extension: 0.3.19
@retrolab/tree-extension: 0.3.19
@retrolab/ui-components: 0.3.19
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | 0.3.x  |
| Version Spec | next |
| Since | v0.3.18 |