### PR TITLE
Automated Changelog Entry for 0.3.21 on 0.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.21
+
+([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.20...d73f5c3e71fc96b467e1dc215431fd328b4da217))
+
+### Enhancements made
+
+- Update to JupyterLab 3.4 [#361](https://github.com/jupyterlab/retrolab/pull/361) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-03-03&to=2022-05-04&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Abollwyvl+updated%3A2022-03-03..2022-05-04&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Afcollonval+updated%3A2022-03-03..2022-05-04&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-03-03..2022-05-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2022-03-03..2022-05-04&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajweill-aws+updated%3A2022-03-03..2022-05-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.20
 
 ([Full Changelog](https://github.com/jupyterlab/retrolab/compare/v0.3.19...c15e26b4773e4866b86bc4125ec9078d1f1d1193))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/retrolab/graphs/contributors?from=2022-02-04&to=2022-03-03&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Agithub-actions+updated%3A2022-02-04..2022-03-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fretrolab+involves%3Ajtpio+updated%3A2022-02-04..2022-03-03&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.19
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.21 on 0.3.x
```
Python version: 0.3.21
npm version: @retrolab/root: 0.1.0
npm workspace versions:
@retrolab/app: 0.3.21
@retrolab/buildutils: 0.3.21
@retrolab/metapackage: 0.3.21
@retrolab/application: 0.3.21
@retrolab/application-extension: 0.3.21
@retrolab/console-extension: 0.3.21
@retrolab/docmanager-extension: 0.3.21
@retrolab/documentsearch-extension: 0.3.21
@retrolab/help-extension: 0.3.21
@retrolab/lab-extension: 0.3.21
@retrolab/notebook-extension: 0.3.21
@retrolab/terminal-extension: 0.3.21
@retrolab/tree-extension: 0.3.21
@retrolab/ui-components: 0.3.21
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/retrolab  |
| Branch  | 0.3.x  |
| Version Spec | next |
| Since | v0.3.20 |